### PR TITLE
修复 3x-ui 入站标签推导导致的出口绑定失效

### DIFF
--- a/xui.go
+++ b/xui.go
@@ -302,6 +302,7 @@ func (x *XUI) Inbounds(live map[string]bool) ([]Inbound, error) {
 		Protocol string          `json:"protocol"`
 		Remark   string          `json:"remark"`
 		Enable   bool            `json:"enable"`
+		Tag      string          `json:"tag"`
 		Stream   json.RawMessage `json:"streamSettings"`
 	}
 	if err := json.Unmarshal(obj, &raw); err != nil {
@@ -315,7 +316,11 @@ func (x *XUI) Inbounds(live map[string]bool) ([]Inbound, error) {
 
 	out := make([]Inbound, 0, len(raw))
 	for _, r := range raw {
-		tag := inboundTag(r.Port, r.Stream)
+		// 3x-ui persists the authoritative Xray tag and returns it in this API.
+		// Do not reconstruct it from the transport: recent 3x-ui versions may
+		// keep a "-tcp" tag for WebSocket inbounds, so reconstruction produces
+		// a routing rule that can never match the running Xray inbound.
+		tag := resolvedInboundTag(r.Tag, r.Port, r.Stream)
 		out = append(out, Inbound{
 			ID: r.ID, Port: r.Port, Protocol: r.Protocol,
 			Remark: r.Remark, Enable: r.Enable,
@@ -343,6 +348,15 @@ func inboundTag(port int, streamSettings json.RawMessage) string {
 		}
 	}
 	return fmt.Sprintf("in-%d-%s", port, network)
+}
+
+// resolvedInboundTag uses the authoritative tag returned by 3x-ui and only
+// reconstructs it for compatibility with older API responses that omit tag.
+func resolvedInboundTag(apiTag string, port int, streamSettings json.RawMessage) string {
+	if apiTag != "" {
+		return apiTag
+	}
+	return inboundTag(port, streamSettings)
 }
 
 // 出站与路由规则统一带这个前缀，便于识别与清理，不碰用户手工加的条目。
@@ -594,7 +608,18 @@ func (x *XUI) CloneToTunnels(templateID int, hosts []string, tunnels []*Tunnel) 
 		}
 		created = append(created, port)
 
-		if err := x.Bind(inboundTagOf(port, raw), t.Node.HostName, tunnels); err != nil {
+		// Read the tag assigned by 3x-ui instead of guessing it from the
+		// template transport. This matters for WS inbounds whose persisted tag
+		// may still use the "tcp" suffix.
+		newRaw, err := x.rawInbound(newID)
+		if err != nil {
+			return created, fmt.Errorf("读取端口 %d 的入站标签失败: %w", port, err)
+		}
+		newTag, _ := newRaw["tag"].(string)
+		if newTag == "" {
+			newTag = inboundTagOf(port, raw)
+		}
+		if err := x.Bind(newTag, t.Node.HostName, tunnels); err != nil {
 			return created, fmt.Errorf("端口 %d 绑定失败: %w", port, err)
 		}
 	}
@@ -862,7 +887,8 @@ func (x *XUI) InboundDetail(id int, publicHost string) (*InboundDetail, error) {
 
 	streamJSON, _ := json.Marshal(raw["streamSettings"])
 	port := int(toFloat(raw["port"]))
-	tag := inboundTag(port, streamJSON)
+	apiTag, _ := raw["tag"].(string)
+	tag := resolvedInboundTag(apiTag, port, streamJSON)
 
 	detail := &InboundDetail{
 		Inbound: Inbound{

--- a/xui_test.go
+++ b/xui_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestRenameExitSuffix(t *testing.T) {
 	cases := []struct{ remark, label, want string }{
@@ -15,5 +18,21 @@ func TestRenameExitSuffix(t *testing.T) {
 		if got != c.want {
 			t.Errorf("renameExitSuffix(%q) = %q, want %q", c.remark, got, c.want)
 		}
+	}
+}
+
+func TestResolvedInboundTagPrefersAPITag(t *testing.T) {
+	stream := json.RawMessage(`{"network":"ws"}`)
+	got := resolvedInboundTag("in-12080-tcp", 12080, stream)
+	if got != "in-12080-tcp" {
+		t.Fatalf("resolvedInboundTag() = %q, want API tag %q", got, "in-12080-tcp")
+	}
+}
+
+func TestResolvedInboundTagFallsBackForLegacyAPI(t *testing.T) {
+	stream := json.RawMessage(`{"network":"ws"}`)
+	got := resolvedInboundTag("", 12080, stream)
+	if got != "in-12080-ws" {
+		t.Fatalf("resolvedInboundTag() = %q, want reconstructed tag %q", got, "in-12080-ws")
 	}
 }


### PR DESCRIPTION
## 修改内容

- 优先使用 3x-ui `/panel/api/inbounds/list` 返回的真实 `tag`
- 仅在旧版 API 未返回 `tag` 时，才根据端口和传输类型重建标签
- 复制入站后重新读取 3x-ui 实际分配的标签再绑定出口
- 入站详情同样展示并使用真实标签
- 添加 API 标签优先级和旧版回退逻辑的回归测试

## 根因

3x-ui 的 WebSocket 入站可能使用 `in-12080-tcp` 作为实际 Xray 标签，但 fanout 根据 `streamSettings.network=ws` 将其重建为 `in-12080-ws`。路由规则引用了不存在的标签，因此无法命中对应的 fanout 出站。

## 影响

修复后，WebSocket 等入站绑定 fanout 出口时会使用 3x-ui 的权威标签，不再因标签推导差异而静默回落到默认直连。

## 验证

- `GOOS=linux GOARCH=amd64 go vet ./...`
- Linux/amd64 测试二进制在 Ubuntu 上运行，全部测试通过
- 实际链路验证：`VLESS + WS → Cloudflare Tunnel → 3x-ui → fanout SOCKS5 → VPN Gate`
- 最终出口 IP 与 fanout 目标隧道一致

Fixes #4
