### PR TITLE
feat: 支持 SOCKS5 UDP ASSOCIATE，让 hysteria2 等客户端的 UDP/DNS 能走隧道

### DIFF
--- a/socks5.go
+++ b/socks5.go
@@ -12,26 +12,28 @@ import (
 	"time"
 )
 
-// SOCKS5 最小实现：只支持 CONNECT。
-// 域名在本进程内解析，隧道里只跑 TCP，避免依赖隧道内的 UDP/DNS。
+// SOCKS5 实现：支持 CONNECT（TCP）与 UDP ASSOCIATE（UDP 中继，见 udp.go）。
+// 域名在本进程内解析，隧道里只跑 TCP 时不用隧道内的 UDP/DNS；
+// UDP 中继则把客户端的 UDP 包放进隧道（netns）转发。
 //
 // 认证走 RFC1929 用户名/口令。端口对公网敞开，没有口令等于谁扫到谁就能用
 // 这条家宽出口，所以凭据是必需的而不是可选项。
 
 const (
-	socksVer5     = 0x05
-	authNone      = 0x00
-	authUserPass  = 0x02
-	authNoAccept  = 0xff
-	authSubVer    = 0x01
-	cmdConnect    = 0x01
-	atypIPv4      = 0x01
-	atypDomain    = 0x03
-	atypIPv6      = 0x04
-	repSuccess    = 0x00
-	repGenFail    = 0x01
-	repHostUnre   = 0x04
-	repCmdNotSupp = 0x07
+	socksVer5       = 0x05
+	authNone        = 0x00
+	authUserPass    = 0x02
+	authNoAccept    = 0xff
+	authSubVer      = 0x01
+	cmdConnect      = 0x01
+	cmdUDPAssociate = 0x03
+	atypIPv4        = 0x01
+	atypDomain      = 0x03
+	atypIPv6        = 0x04
+	repSuccess      = 0x00
+	repGenFail      = 0x01
+	repHostUnre     = 0x04
+	repCmdNotSupp   = 0x07
 )
 
 // serveSocks 处理一条 SOCKS5 连接。dial 决定流量从哪条链路出去。
@@ -44,13 +46,19 @@ func serveSocks(client net.Conn, cred *SocksCred, dial func(network, addr string
 		return
 	}
 
-	addr, err := socksReadRequest(client)
+	cmd, addr, err := socksReadRequestWithCmd(client)
 	if err != nil {
 		if errors.Is(err, errCmdNotSupported) {
 			socksReply(client, repCmdNotSupp)
 		} else {
 			socksReply(client, repGenFail)
 		}
+		return
+	}
+
+	if cmd == cmdUDPAssociate {
+		_ = client.SetDeadline(time.Time{})
+		serveUDPAssociate(client, dial)
 		return
 	}
 
@@ -143,18 +151,33 @@ func readLenPrefixed(c net.Conn) ([]byte, error) {
 	return b, nil
 }
 
-var errCmdNotSupported = errors.New("仅支持 CONNECT")
+var errCmdNotSupported = errors.New("仅支持 CONNECT 与 UDP ASSOCIATE")
 
 // errIPv6NotSupported 表示拒绝 IPv6 目标：隧道内只有 IPv4。
 var errIPv6NotSupported = errors.New("隧道内不支持 IPv6")
 
+// socksReadRequest 读请求并返回目标地址（仅 CONNECT，兼容旧调用）。
 func socksReadRequest(c net.Conn) (string, error) {
-	head := make([]byte, 4)
-	if _, err := io.ReadFull(c, head); err != nil {
+	cmd, addr, err := socksReadRequestWithCmd(c)
+	if err != nil {
 		return "", err
 	}
-	if head[1] != cmdConnect {
+	if cmd != cmdConnect {
 		return "", errCmdNotSupported
+	}
+	return addr, nil
+}
+
+// socksReadRequestWithCmd 读请求并返回命令与目标地址，支持 CONNECT 与 UDP ASSOCIATE。
+func socksReadRequestWithCmd(c net.Conn) (byte, string, error) {
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(c, head); err != nil {
+		return 0, "", err
+	}
+	switch head[1] {
+	case cmdConnect, cmdUDPAssociate:
+	default:
+		return 0, "", errCmdNotSupported
 	}
 
 	var host string
@@ -162,39 +185,52 @@ func socksReadRequest(c net.Conn) (string, error) {
 	case atypIPv4:
 		b := make([]byte, 4)
 		if _, err := io.ReadFull(c, b); err != nil {
-			return "", err
+			return 0, "", err
 		}
 		host = net.IP(b).String()
 	case atypIPv6:
 		// 隧道内没有 IPv6 路由，放行只会让这条连接绕开隧道
 		b := make([]byte, 16)
 		if _, err := io.ReadFull(c, b); err != nil {
-			return "", err
+			return 0, "", err
 		}
-		return "", errIPv6NotSupported
+		return 0, "", errIPv6NotSupported
 	case atypDomain:
 		l := make([]byte, 1)
 		if _, err := io.ReadFull(c, l); err != nil {
-			return "", err
+			return 0, "", err
 		}
 		b := make([]byte, int(l[0]))
 		if _, err := io.ReadFull(c, b); err != nil {
-			return "", err
+			return 0, "", err
 		}
 		host = string(b)
 	default:
-		return "", fmt.Errorf("不支持的地址类型 %d", head[3])
+		return 0, "", fmt.Errorf("不支持的地址类型 %d", head[3])
 	}
 
 	pb := make([]byte, 2)
 	if _, err := io.ReadFull(c, pb); err != nil {
-		return "", err
+		return 0, "", err
 	}
-	return net.JoinHostPort(host, strconv.Itoa(int(binary.BigEndian.Uint16(pb)))), nil
+	return head[1], net.JoinHostPort(host, strconv.Itoa(int(binary.BigEndian.Uint16(pb)))), nil
 }
 
 func socksReply(c net.Conn, code byte) error {
 	_, err := c.Write([]byte{socksVer5, code, 0x00, atypIPv4, 0, 0, 0, 0, 0, 0})
+	return err
+}
+
+// socksReplyWith 回一个带 BND 地址/端口的应答（UDP ASSOCIATE 需要真实中继地址）。
+func socksReplyWith(c net.Conn, code byte, ip net.IP, port int) error {
+	if ip == nil || ip.To4() == nil {
+		ip = net.IPv4zero
+	}
+	b := make([]byte, 0, 10)
+	b = append(b, socksVer5, code, 0x00, atypIPv4)
+	b = append(b, ip.To4()...)
+	b = append(b, byte(port>>8), byte(port))
+	_, err := c.Write(b)
 	return err
 }
 

--- a/udp.go
+++ b/udp.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/binary"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// SOCKS5 UDP ASSOCIATE 支持。
+// 原版 fanout 只实现 CONNECT，Xray 转发 hysteria2 客户端的 DNS/QUIC 等
+// UDP 包时走 UDP ASSOCIATE 会被拒，导致手机端（DNS/QUIC 走隧道）连不上。
+// 这里按 RFC1928 补上 UDP 中继：每个客户端 UDP 包在隧道(netns)内建立到
+// 目标的已连接 UDP socket 转发，应答再按 SOCKS5 UDP 头回给客户端。
+
+const udpIdleTimeout = 60 * time.Second
+
+// udpSession 一条 (客户端, 目标) 对应的隧道内 UDP socket。
+type udpSession struct {
+	conn   net.Conn
+	client *net.UDPAddr
+	atyp   byte
+	addr   []byte // 原始目标地址字节（回包头用）
+	port   uint16
+}
+
+// serveUDPAssociate 处理 SOCKS5 UDP ASSOCIATE 请求。
+// client 是已完成认证的 TCP 控制连接；dial 负责在隧道内建连。
+func serveUDPAssociate(client net.Conn, dial func(network, addr string) (net.Conn, error)) {
+	relay, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero})
+	if err != nil {
+		_ = socksReply(client, repGenFail)
+		return
+	}
+	defer relay.Close()
+
+	// BND 地址：公网客户端连进来时用连接本端 IP，本机客户端就是 127.0.0.1
+	bndIP := net.IPv4zero
+	if la, ok := client.LocalAddr().(*net.TCPAddr); ok && la.IP != nil && !la.IP.IsUnspecified() {
+		bndIP = la.IP
+	}
+	bndPort := relay.LocalAddr().(*net.UDPAddr).Port
+	if err := socksReplyWith(client, repSuccess, bndIP, bndPort); err != nil {
+		return
+	}
+
+	// TCP 控制连接关闭时结束整个 association
+	go func() {
+		_, _ = client.Read(make([]byte, 1))
+		_ = relay.Close()
+	}()
+
+	var mu sync.Mutex
+	sessions := make(map[string]*udpSession)
+	defer func() {
+		mu.Lock()
+		for k, s := range sessions {
+			_ = s.conn.Close()
+			delete(sessions, k)
+		}
+		mu.Unlock()
+	}()
+
+	buf := make([]byte, 65535)
+	for {
+		_ = relay.SetReadDeadline(time.Now().Add(udpIdleTimeout))
+		n, src, err := relay.ReadFromUDP(buf)
+		if err != nil {
+			return
+		}
+		atyp, addrBytes, host, port, payload, ok := parseUDPReqHeader(buf[:n])
+		if !ok {
+			continue
+		}
+		dest := net.JoinHostPort(host, strconv.Itoa(int(port)))
+		key := src.String() + "|" + dest
+
+		mu.Lock()
+		s := sessions[key]
+		if s == nil {
+			mu.Unlock()
+			conn, derr := dial("udp", dest)
+			if derr != nil {
+				continue
+			}
+			mu.Lock()
+			if s2 := sessions[key]; s2 != nil {
+				_ = conn.Close()
+				s = s2
+			} else {
+				s = &udpSession{conn: conn, client: src, atyp: atyp, addr: addrBytes, port: port}
+				sessions[key] = s
+				go relayUDP(s, relay, &mu, sessions, key)
+			}
+		}
+		mu.Unlock()
+
+		if _, werr := s.conn.Write(payload); werr != nil {
+			// 隧道断了，reader 会负责清理
+		}
+	}
+}
+
+// relayUDP 读取隧道内 UDP socket 的应答，回写给客户端。
+func relayUDP(s *udpSession, relay *net.UDPConn, mu *sync.Mutex, sessions map[string]*udpSession, key string) {
+	buf := make([]byte, 65535)
+	for {
+		_ = s.conn.SetReadDeadline(time.Now().Add(udpIdleTimeout))
+		n, err := s.conn.Read(buf)
+		if err != nil {
+			break
+		}
+		pkt := buildUDPRespHeader(s.atyp, s.addr, s.port, buf[:n])
+		if _, err := relay.WriteToUDP(pkt, s.client); err != nil {
+			break
+		}
+	}
+	mu.Lock()
+	_ = s.conn.Close()
+	delete(sessions, key)
+	mu.Unlock()
+}
+
+// parseUDPReqHeader 解析 SOCKS5 UDP 请求头（RSV FRAG ATYP ADDR PORT DATA）。
+func parseUDPReqHeader(b []byte) (atyp byte, addrBytes []byte, host string, port uint16, payload []byte, ok bool) {
+	if len(b) < 4 || b[0] != 0 || b[1] != 0 || b[2] != 0 {
+		return 0, nil, "", 0, nil, false
+	}
+	atyp = b[3]
+	pos := 4
+	switch atyp {
+	case atypIPv4:
+		if len(b) < pos+4+2 {
+			return 0, nil, "", 0, nil, false
+		}
+		addrBytes = append([]byte(nil), b[pos:pos+4]...)
+		host = net.IP(b[pos : pos+4]).String()
+		pos += 4
+	case atypDomain:
+		if len(b) < pos+1 {
+			return 0, nil, "", 0, nil, false
+		}
+		l := int(b[pos])
+		pos++
+		if len(b) < pos+l+2 {
+			return 0, nil, "", 0, nil, false
+		}
+		addrBytes = append([]byte(nil), b[pos:pos+l]...)
+		host = string(b[pos : pos+l])
+		pos += l
+	case atypIPv6:
+		return 0, nil, "", 0, nil, false // 隧道只支持 IPv4
+	default:
+		return 0, nil, "", 0, nil, false
+	}
+	if len(b) < pos+2 {
+		return 0, nil, "", 0, nil, false
+	}
+	port = binary.BigEndian.Uint16(b[pos : pos+2])
+	pos += 2
+	return atyp, addrBytes, host, port, b[pos:], true
+}
+
+// buildUDPRespHeader 组装回给客户端的 SOCKS5 UDP 包头。
+func buildUDPRespHeader(atyp byte, addrBytes []byte, port uint16, data []byte) []byte {
+	head := make([]byte, 0, 4+len(addrBytes)+2)
+	head = append(head, 0, 0, 0, atyp)
+	head = append(head, addrBytes...)
+	head = append(head, byte(port>>8), byte(port))
+	return append(head, data...)
+}

--- a/udp_test.go
+++ b/udp_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func TestParseUDPReqHeaderIPv4(t *testing.T) {
+	b := []byte{0, 0, 0, atypIPv4, 8, 8, 8, 8, 0, 53, 1, 2, 3}
+	atyp, addr, host, port, payload, ok := parseUDPReqHeader(b)
+	if !ok || atyp != atypIPv4 || host != "8.8.8.8" || port != 53 || len(payload) != 3 || payload[0] != 1 {
+		t.Fatalf("bad parse: ok=%v atyp=%v host=%v port=%v payload=%v", ok, atyp, host, port, payload)
+	}
+	if len(addr) != 4 || addr[0] != 8 {
+		t.Fatalf("bad addr bytes: %v", addr)
+	}
+}
+
+func TestParseUDPReqHeaderDomain(t *testing.T) {
+	b := []byte{0, 0, 0, atypDomain, 3, 'd', 'n', 's', 0, 35, 9, 9}
+	atyp, _, host, port, payload, ok := parseUDPReqHeader(b)
+	if !ok || atyp != atypDomain || host != "dns" || port != 35 || len(payload) != 2 {
+		t.Fatalf("bad parse: ok=%v atyp=%v host=%v port=%v payload=%v", ok, atyp, host, port, payload)
+	}
+}
+
+func TestParseUDPReqHeaderBad(t *testing.T) {
+	if _, _, _, _, _, ok := parseUDPReqHeader([]byte{1, 0, 0, atypIPv4, 1, 2, 3, 4, 0, 53}); ok {
+		t.Fatal("rsv nonzero should fail")
+	}
+	ip6 := []byte{0, 0, 0, atypIPv6}
+	ip6 = append(ip6, make([]byte, 16)...)
+	ip6 = append(ip6, 0, 53)
+	if _, _, _, _, _, ok := parseUDPReqHeader(ip6); ok {
+		t.Fatal("ipv6 should fail")
+	}
+	if _, _, _, _, _, ok := parseUDPReqHeader([]byte{0, 0, 0, 0x09, 1, 2, 3, 4, 0, 53}); ok {
+		t.Fatal("unknown atyp should fail")
+	}
+}
+
+func TestBuildUDPRespHeader(t *testing.T) {
+	pkt := buildUDPRespHeader(atypIPv4, []byte{8, 8, 8, 8}, 53, []byte{1, 2})
+	if len(pkt) != 12 {
+		t.Fatalf("bad packet len: %v", pkt)
+	}
+	head := pkt[:10]
+	want := []byte{0, 0, 0, atypIPv4, 8, 8, 8, 8, 0, 53}
+	for i := range want {
+		if head[i] != want[i] {
+			t.Fatalf("bad header: %v", pkt)
+		}
+	}
+	if pkt[10] != 1 || pkt[11] != 2 {
+		t.Fatalf("bad data: %v", pkt)
+	}
+}
+
+func TestSocksReplyWith(t *testing.T) {
+	s, c := net.Pipe()
+	defer s.Close()
+	defer c.Close()
+	go func() {
+		_ = socksReplyWith(s, repSuccess, net.IPv4(1, 2, 3, 4), 5555)
+		_ = s.Close()
+	}()
+	b := make([]byte, 10)
+	if _, err := c.Read(b); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{socksVer5, repSuccess, 0x00, atypIPv4, 1, 2, 3, 4, 0x15, 0xb3}
+	for i := range want {
+		if b[i] != want[i] {
+			t.Fatalf("bad reply: %v", b)
+		}
+	}
+}


### PR DESCRIPTION
### 背景
fanout 的 SOCKS5 目前只实现了 CONNECT（TCP）。3x-ui/hysteria2 这类客户端会把 DNS 查询、QUIC 等 UDP 包通过 SOCKS5 UDP ASSOCIATE 转给隧道，但服务端直接拒绝（仅支持 CONNECT），导致手机端域名解析失败、Google/YouTube 等连不上；电脑端客户端通常本地解析 DNS、只走 TCP，所以表现正常。

### 改动
- `socks5.go`：增加 `cmdUDPAssociate` 分支；把请求解析拆出 `socksReadRequestWithCmd`，保留旧 `socksReadRequest` 兼容；新增 `socksReplyWith` 返回真实 BND 地址/端口。
- `udp.go`（新增）：按 RFC1928 实现 UDP 中继。每个 (客户端, 目标) 在 netns 内建立一个已连接 UDP socket 转发，应答按 SOCKS5 UDP 头回写给客户端；TCP 控制连接关闭或空闲 60s 自动清理。
- `udp_test.go`（新增）：UDP 头解析、回包头、BND 应答的单元测试。

### 测试
- `go vet ./...`、`go test ./...` 通过；
- 实测：外部客户端通过 SOCKS5 UDP ASSOCIATE 向 8.8.8.8:53 发 DNS 查询，正常收到应答（流量走隧道出口 IP）。

### 说明
隧道仍只转发 IPv4；UDP 目标为 IPv6 时按原设计拒绝，避免绕开隧道泄漏真实地址。